### PR TITLE
Fixed function indenting

### DIFF
--- a/syntax/zsh.vim
+++ b/syntax/zsh.vim
@@ -13,11 +13,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-if v:version > 704 || (v:version == 704 && has("patch1142"))
-    syn iskeyword @,48-57,_,192-255,#,-
-else
-    setlocal iskeyword+=-
-endif
+setlocal iskeyword+=-,!
 if get(g:, 'zsh_fold_enable', 0)
     setlocal foldmethod=syntax
 endif


### PR DESCRIPTION
Functions aren't indented properly by the sh indent file. I've modified
it here slightly to allow for proper indenting of functions.

e.g. 

```zsh
function hello_world {
    echo "hello_world"
}
```

turns into

```zsh
function hello_world {
echo "hello_world"
}
```

But now with this PR it will stay indented.
