### PR TITLE
Fix zshOldSubst command substitutions that end with embedded backslashes when zsh.vim is embedded

### DIFF
--- a/syntax/zsh.vim
+++ b/syntax/zsh.vim
@@ -2,7 +2,7 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2018-07-13
+" Latest Revision:      2019-12-26
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
 
@@ -356,7 +356,7 @@ syn region  zshBrackets         transparent start='{' skip='\\}'
                                 \ end='}' contains=TOP fold
 syn region  zshSubst            matchgroup=zshSubstDelim start='\${' skip='\\}'
                                 \ end='}' contains=@zshSubst,zshBrackets,zshQuoted,zshString fold
-syn region  zshOldSubst         matchgroup=zshSubstDelim start=+`+ skip=+\\`+
+syn region  zshOldSubst         matchgroup=zshSubstDelim start=+`+ skip=+\\[\\`]+
                                 \ end=+`+ contains=TOP,zshOldSubst fold
 
 syn sync    minlines=50 maxlines=90


### PR DESCRIPTION
Set `g:markdown_fenced_languages = ['zsh']` and open the following file:

````markdown
/* vim:set ft=markdown: */
```zsh
print -r "`print -r \\\\\\\\`" foo
```
````

The `foo` will be highlighted as zshOldSubst. The attached patch fixes that.

I was able to reproduce the issue with another language that embeds zsh.vim (so it's not specific to markdown.vim), but I wasn't able to reproduce it without embedding. I am posting this as a PR, though, so it'll be easy for you to merge it if you think it's nonetheless correct.