### PR TITLE
Remove leading , from b:match_words

### DIFF
--- a/ftplugin/zsh.vim
+++ b/ftplugin/zsh.vim
@@ -32,7 +32,7 @@ if executable('zsh')
   let b:undo_ftplugin .= 'keywordprg< errorformat< makeprg<'
 endif
 
-let b:match_words = ',\<if\>:\<elif\>:\<else\>:\<fi\>'
+let b:match_words = '\<if\>:\<elif\>:\<else\>:\<fi\>'
       \ . ',\<case\>:^\s*([^)]*):\<esac\>'
       \ . ',\<\%(select\|while\|until\|repeat\|for\%(each\)\=\)\>:\<done\>'
 let b:match_skip = 's:comment\|string\|heredoc\|subst'


### PR DESCRIPTION
For reasons I have not yet elucidated, this leading `,` causes `%` to
behave wrongly when placed before a bracket or match. That is, given the
document below (with `&filetype=zsh`):

    f () {
      :
    }

If you place the cursor on `f` and press `%`, you should expect to jump
to the matching parentheses. With the leading `,` this behavior is
broken and no match is made. Removing it corrects the behavior.
