### PR TITLE
Extract a compiler plugin from the ftplugin

### DIFF
--- a/compiler/zsh.vim
+++ b/compiler/zsh.vim
@@ -1,0 +1,23 @@
+" Vim compiler file
+" Compiler:	Zsh
+" Maintainer:	Doug Kearns <dougkearns@gmail.com>
+" Last Change:	2020 Sep 6
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "zsh"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+CompilerSet makeprg=zsh\ -n\ --\ %:S
+CompilerSet errorformat=%f:\ line\ %l:\ %m,
+		       \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/zsh.vim
+++ b/ftplugin/zsh.vim
@@ -19,13 +19,13 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl com< cms< fo< "
 
 if executable('zsh')
- if !has('gui_running') && executable('less')
-   command! -buffer -nargs=1 RunHelp silent exe '!MANPAGER= zsh -ic "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
- elseif has('terminal')
-   command! -buffer -nargs=1 RunHelp silent exe ':term zsh -ic "autoload -Uz run-help; run-help <args>"'
- else
-   command! -buffer -nargs=1 RunHelp echo system('zsh -ic "autoload -Uz run-help; run-help <args> 2>/dev/null"')
- endif
+  if !has('gui_running') && executable('less')
+    command! -buffer -nargs=1 RunHelp silent exe '!MANPAGER= zsh -ic "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
+  elseif has('terminal')
+    command! -buffer -nargs=1 RunHelp silent exe ':term zsh -ic "autoload -Uz run-help; run-help <args>"'
+  else
+    command! -buffer -nargs=1 RunHelp echo system('zsh -ic "autoload -Uz run-help; run-help <args> 2>/dev/null"')
+  endif
   if !exists('current_compiler')
     compiler zsh
   endif

--- a/ftplugin/zsh.vim
+++ b/ftplugin/zsh.vim
@@ -26,10 +26,11 @@ if executable('zsh')
  else
    command! -buffer -nargs=1 RunHelp echo system('zsh -ic "autoload -Uz run-help; run-help <args> 2>/dev/null"')
  endif
+  if !exists('current_compiler')
+    compiler zsh
+  endif
   setlocal keywordprg=:RunHelp
-  setlocal makeprg=zsh\ -n\ --\ %:S
-  setlocal errorformat=%f:\ line\ %l:\ %m
-  let b:undo_ftplugin .= 'keywordprg< errorformat< makeprg<'
+  let b:undo_ftplugin .= 'keywordprg<'
 endif
 
 let b:match_words = '\<if\>:\<elif\>:\<else\>:\<fi\>'


### PR DESCRIPTION
I've had a compiler plugin for some time but just noticed that `'efm'` and `'mp'` were being set in the ftplugin.  Having these set in a proper compiler plugin seems like a good idea but I'm not particularly attached to it.

I think there's also a few third-party plugins like Dispatch that parse the compiler plugins for these option settings.

If you think it's worth committing I'm more than happy to assign maintainership to you, @chrisbra, if you're into that sort of thing. :) 