### PR TITLE
Restore case-sensitive syntax matching of the typeset builtin

### DIFF
--- a/syntax/zsh.vim
+++ b/syntax/zsh.vim
@@ -354,6 +354,8 @@ syn match   zshOption /
       \ \%(\%(\<no_\?\)\?xtrace\>\)\|
       \ \%(\%(\<no_\?\)\?zle\>\)/ nextgroup=zshOption,zshComment skipwhite contained
 
+syn case match
+
 syn keyword zshTypes            float integer local typeset declare private readonly
 
 " XXX: this may be too much


### PR DESCRIPTION
The `typeset` (and friends) builtin commands were being matched case insensitively.

This restoration of case sensitivity after matching options seems to have been accidentally removed in revision
c935c43dff1a50233c925965ff0bb3a8ed4d046c

There were a couple of false positives in the Zsh distribution files.