### PR TITLE
Improve performance of zshOption by using keywords

### DIFF
--- a/make-options.zsh
+++ b/make-options.zsh
@@ -5,12 +5,9 @@ src=$1
 
 typeset -U all=()
 for opt in $(grep '^pindex([A-Za-z_]*)$' "$src/Doc/Zsh/options.yo"); do
-	x=${${(L)opt#pindex\(}%\)}
-	[[ $x =~ '^no_' ]] && all+=(${x/no_/})
+	all+=(${${(L)opt#pindex\(}%\)})
 done
-all+=(no_match)  # Special case: no_match / no_no_match.
 
-print -r 'syn match   zshOption nextgroup=zshOption,zshComment skipwhite contained /\v'
-print -r '            \<%(no_?)?%('
-print -r "            \\${(oj:|:)all//_/_?}"
-print -r '            \)>/'  # Note: a space here will break the last entry.
+IFS=$'\n' lines=($(fold -sw100 <<<${(oj: :)all}))
+print -r 'syn keyword zshOption nextgroup=zshOption,zshComment skipwhite contained'
+print    "           \\\ ${(j:\n           \\ :)lines}"

--- a/syntax/zsh.vim
+++ b/syntax/zsh.vim
@@ -144,10 +144,120 @@ syn case ignore
 syn match   zshOptStart
             \ /\v^\s*%(%(un)?setopt|set\s+[-+]o)/
             \ nextgroup=zshOption skipwhite
-syn match   zshOption nextgroup=zshOption,zshComment skipwhite contained /\v
-            \<%(no_?)?%(
-            \auto_?cd|auto_?pushd|cdable_?vars|cd_?silent|chase_?dots|chase_?links|posix_?cd|pushd_?ignore_?dups|pushd_?minus|pushd_?silent|pushd_?to_?home|always_?last_?prompt|always_?to_?end|auto_?list|auto_?menu|auto_?name_?dirs|auto_?param_?keys|auto_?param_?slash|auto_?remove_?slash|bash_?auto_?list|complete_?aliases|complete_?in_?word|glob_?complete|hash_?list_?all|list_?ambiguous|list_?beep|list_?packed|list_?rows_?first|list_?types|menu_?complete|rec_?exact|bad_?pattern|bare_?glob_?qual|brace_?ccl|case_?glob|case_?match|case_?paths|csh_?null_?glob|equals|extended_?glob|force_?float|glob|glob_?assign|glob_?dots|glob_?star_?short|glob_?subst|hist_?subst_?pattern|ignore_?braces|ignore_?close_?braces|ksh_?glob|magic_?equal_?subst|mark_?dirs|multibyte|nomatch|null_?glob|numeric_?glob_?sort|rc_?expand_?param|rematch_?pcre|sh_?glob|unset|warn_?create_?global|warn_?nested_?var|warnnestedvar|append_?history|bang_?hist|extended_?history|hist_?allow_?clobber|hist_?beep|hist_?expire_?dups_?first|hist_?fcntl_?lock|hist_?find_?no_?dups|hist_?ignore_?all_?dups|hist_?ignore_?dups|hist_?ignore_?space|hist_?lex_?words|hist_?no_?functions|hist_?no_?store|hist_?reduce_?blanks|hist_?save_?by_?copy|hist_?save_?no_?dups|hist_?verify|inc_?append_?history|inc_?append_?history_?time|share_?history|all_?export|global_?export|global_?rcs|rcs|aliases|clobber|clobber_?empty|correct|correct_?all|dvorak|flow_?control|ignore_?eof|interactive_?comments|hash_?cmds|hash_?dirs|hash_?executables_?only|mail_?warning|path_?dirs|path_?script|print_?eight_?bit|print_?exit_?value|rc_?quotes|rm_?star_?silent|rm_?star_?wait|short_?loops|short_?repeat|sun_?keyboard_?hack|auto_?continue|auto_?resume|bg_?nice|check_?jobs|check_?running_?jobs|hup|long_?list_?jobs|monitor|notify|posix_?jobs|prompt_?bang|prompt_?cr|prompt_?sp|prompt_?percent|prompt_?subst|transient_?rprompt|alias_?func_?def|c_?bases|c_?precedences|debug_?before_?cmd|err_?exit|err_?return|eval_?lineno|exec|function_?argzero|local_?loops|local_?options|local_?patterns|local_?traps|multi_?func_?def|multios|octal_?zeroes|pipe_?fail|source_?trace|typeset_?silent|typeset_?to_?unset|verbose|xtrace|append_?create|bash_?rematch|bsd_?echo|continue_?on_?error|csh_?junkie_?history|csh_?junkie_?loops|csh_?junkie_?quotes|csh_?nullcmd|ksh_?arrays|ksh_?autoload|ksh_?option_?print|ksh_?typeset|ksh_?zero_?subscript|posix_?aliases|posix_?argzero|posix_?builtins|posix_?identifiers|posix_?strings|posix_?traps|sh_?file_?expansion|sh_?nullcmd|sh_?option_?letters|sh_?word_?split|traps_?async|interactive|login|privileged|restricted|shin_?stdin|single_?command|beep|combining_?chars|emacs|overstrike|single_?line_?zle|vi|zle|brace_?expand|dot_?glob|hash_?all|hist_?append|hist_?expand|log|mail_?warn|one_?cmd|physical|prompt_?vars|stdin|track_?all|no_?match
-            \)>/
+syn keyword zshOption nextgroup=zshOption,zshComment skipwhite contained
+           \ auto_cd no_auto_cd autocd noautocd auto_pushd no_auto_pushd autopushd noautopushd cdable_vars
+           \ no_cdable_vars cdablevars nocdablevars cd_silent no_cd_silent cdsilent nocdsilent chase_dots
+           \ no_chase_dots chasedots nochasedots chase_links no_chase_links chaselinks nochaselinks posix_cd
+           \ posixcd no_posix_cd noposixcd pushd_ignore_dups no_pushd_ignore_dups pushdignoredups
+           \ nopushdignoredups pushd_minus no_pushd_minus pushdminus nopushdminus pushd_silent no_pushd_silent
+           \ pushdsilent nopushdsilent pushd_to_home no_pushd_to_home pushdtohome nopushdtohome
+           \ always_last_prompt no_always_last_prompt alwayslastprompt noalwayslastprompt always_to_end
+           \ no_always_to_end alwaystoend noalwaystoend auto_list no_auto_list autolist noautolist auto_menu
+           \ no_auto_menu automenu noautomenu auto_name_dirs no_auto_name_dirs autonamedirs noautonamedirs
+           \ auto_param_keys no_auto_param_keys autoparamkeys noautoparamkeys auto_param_slash
+           \ no_auto_param_slash autoparamslash noautoparamslash auto_remove_slash no_auto_remove_slash
+           \ autoremoveslash noautoremoveslash bash_auto_list no_bash_auto_list bashautolist nobashautolist
+           \ complete_aliases no_complete_aliases completealiases nocompletealiases complete_in_word
+           \ no_complete_in_word completeinword nocompleteinword glob_complete no_glob_complete globcomplete
+           \ noglobcomplete hash_list_all no_hash_list_all hashlistall nohashlistall list_ambiguous
+           \ no_list_ambiguous listambiguous nolistambiguous list_beep no_list_beep listbeep nolistbeep
+           \ list_packed no_list_packed listpacked nolistpacked list_rows_first no_list_rows_first listrowsfirst
+           \ nolistrowsfirst list_types no_list_types listtypes nolisttypes menu_complete no_menu_complete
+           \ menucomplete nomenucomplete rec_exact no_rec_exact recexact norecexact bad_pattern no_bad_pattern
+           \ badpattern nobadpattern bare_glob_qual no_bare_glob_qual bareglobqual nobareglobqual brace_ccl
+           \ no_brace_ccl braceccl nobraceccl case_glob no_case_glob caseglob nocaseglob case_match
+           \ no_case_match casematch nocasematch case_paths no_case_paths casepaths nocasepaths csh_null_glob
+           \ no_csh_null_glob cshnullglob nocshnullglob equals no_equals noequals extended_glob no_extended_glob
+           \ extendedglob noextendedglob force_float no_force_float forcefloat noforcefloat glob no_glob noglob
+           \ glob_assign no_glob_assign globassign noglobassign glob_dots no_glob_dots globdots noglobdots
+           \ glob_star_short no_glob_star_short globstarshort noglobstarshort glob_subst no_glob_subst globsubst
+           \ noglobsubst hist_subst_pattern no_hist_subst_pattern histsubstpattern nohistsubstpattern
+           \ ignore_braces no_ignore_braces ignorebraces noignorebraces ignore_close_braces
+           \ no_ignore_close_braces ignoreclosebraces noignoreclosebraces ksh_glob no_ksh_glob kshglob nokshglob
+           \ magic_equal_subst no_magic_equal_subst magicequalsubst nomagicequalsubst mark_dirs no_mark_dirs
+           \ markdirs nomarkdirs multibyte no_multibyte nomultibyte nomatch no_nomatch nonomatch null_glob
+           \ no_null_glob nullglob nonullglob numeric_glob_sort no_numeric_glob_sort numericglobsort
+           \ nonumericglobsort rc_expand_param no_rc_expand_param rcexpandparam norcexpandparam rematch_pcre
+           \ no_rematch_pcre rematchpcre norematchpcre sh_glob no_sh_glob shglob noshglob unset no_unset nounset
+           \ warn_create_global no_warn_create_global warncreateglobal nowarncreateglobal warn_nested_var
+           \ no_warn_nested_var warnnestedvar no_warnnestedvar append_history no_append_history appendhistory
+           \ noappendhistory bang_hist no_bang_hist banghist nobanghist extended_history no_extended_history
+           \ extendedhistory noextendedhistory hist_allow_clobber no_hist_allow_clobber histallowclobber
+           \ nohistallowclobber hist_beep no_hist_beep histbeep nohistbeep hist_expire_dups_first
+           \ no_hist_expire_dups_first histexpiredupsfirst nohistexpiredupsfirst hist_fcntl_lock
+           \ no_hist_fcntl_lock histfcntllock nohistfcntllock hist_find_no_dups no_hist_find_no_dups
+           \ histfindnodups nohistfindnodups hist_ignore_all_dups no_hist_ignore_all_dups histignorealldups
+           \ nohistignorealldups hist_ignore_dups no_hist_ignore_dups histignoredups nohistignoredups
+           \ hist_ignore_space no_hist_ignore_space histignorespace nohistignorespace hist_lex_words
+           \ no_hist_lex_words histlexwords nohistlexwords hist_no_functions no_hist_no_functions
+           \ histnofunctions nohistnofunctions hist_no_store no_hist_no_store histnostore nohistnostore
+           \ hist_reduce_blanks no_hist_reduce_blanks histreduceblanks nohistreduceblanks hist_save_by_copy
+           \ no_hist_save_by_copy histsavebycopy nohistsavebycopy hist_save_no_dups no_hist_save_no_dups
+           \ histsavenodups nohistsavenodups hist_verify no_hist_verify histverify nohistverify
+           \ inc_append_history no_inc_append_history incappendhistory noincappendhistory
+           \ inc_append_history_time no_inc_append_history_time incappendhistorytime noincappendhistorytime
+           \ share_history no_share_history sharehistory nosharehistory all_export no_all_export allexport
+           \ noallexport global_export no_global_export globalexport noglobalexport global_rcs no_global_rcs
+           \ globalrcs noglobalrcs rcs no_rcs norcs aliases no_aliases noaliases clobber no_clobber noclobber
+           \ clobber_empty no_clobber_empty clobberempty noclobberempty correct no_correct nocorrect correct_all
+           \ no_correct_all correctall nocorrectall dvorak no_dvorak nodvorak flow_control no_flow_control
+           \ flowcontrol noflowcontrol ignore_eof no_ignore_eof ignoreeof noignoreeof interactive_comments
+           \ no_interactive_comments interactivecomments nointeractivecomments hash_cmds no_hash_cmds hashcmds
+           \ nohashcmds hash_dirs no_hash_dirs hashdirs nohashdirs hash_executables_only
+           \ no_hash_executables_only hashexecutablesonly nohashexecutablesonly mail_warning no_mail_warning
+           \ mailwarning nomailwarning path_dirs no_path_dirs pathdirs nopathdirs path_script no_path_script
+           \ pathscript nopathscript print_eight_bit no_print_eight_bit printeightbit noprinteightbit
+           \ print_exit_value no_print_exit_value printexitvalue noprintexitvalue rc_quotes no_rc_quotes
+           \ rcquotes norcquotes rm_star_silent no_rm_star_silent rmstarsilent normstarsilent rm_star_wait
+           \ no_rm_star_wait rmstarwait normstarwait short_loops no_short_loops shortloops noshortloops
+           \ short_repeat no_short_repeat shortrepeat noshortrepeat sun_keyboard_hack no_sun_keyboard_hack
+           \ sunkeyboardhack nosunkeyboardhack auto_continue no_auto_continue autocontinue noautocontinue
+           \ auto_resume no_auto_resume autoresume noautoresume bg_nice no_bg_nice bgnice nobgnice check_jobs
+           \ no_check_jobs checkjobs nocheckjobs check_running_jobs no_check_running_jobs checkrunningjobs
+           \ nocheckrunningjobs hup no_hup nohup long_list_jobs no_long_list_jobs longlistjobs nolonglistjobs
+           \ monitor no_monitor nomonitor notify no_notify nonotify posix_jobs posixjobs no_posix_jobs
+           \ noposixjobs prompt_bang no_prompt_bang promptbang nopromptbang prompt_cr no_prompt_cr promptcr
+           \ nopromptcr prompt_sp no_prompt_sp promptsp nopromptsp prompt_percent no_prompt_percent
+           \ promptpercent nopromptpercent prompt_subst no_prompt_subst promptsubst nopromptsubst
+           \ transient_rprompt no_transient_rprompt transientrprompt notransientrprompt alias_func_def
+           \ no_alias_func_def aliasfuncdef noaliasfuncdef c_bases no_c_bases cbases nocbases c_precedences
+           \ no_c_precedences cprecedences nocprecedences debug_before_cmd no_debug_before_cmd debugbeforecmd
+           \ nodebugbeforecmd err_exit no_err_exit errexit noerrexit err_return no_err_return errreturn
+           \ noerrreturn eval_lineno no_eval_lineno evallineno noevallineno exec no_exec noexec function_argzero
+           \ no_function_argzero functionargzero nofunctionargzero local_loops no_local_loops localloops
+           \ nolocalloops local_options no_local_options localoptions nolocaloptions local_patterns
+           \ no_local_patterns localpatterns nolocalpatterns local_traps no_local_traps localtraps nolocaltraps
+           \ multi_func_def no_multi_func_def multifuncdef nomultifuncdef multios no_multios nomultios
+           \ octal_zeroes no_octal_zeroes octalzeroes nooctalzeroes pipe_fail no_pipe_fail pipefail nopipefail
+           \ source_trace no_source_trace sourcetrace nosourcetrace typeset_silent no_typeset_silent
+           \ typesetsilent notypesetsilent typeset_to_unset no_typeset_to_unset typesettounset notypesettounset
+           \ verbose no_verbose noverbose xtrace no_xtrace noxtrace append_create no_append_create appendcreate
+           \ noappendcreate bash_rematch no_bash_rematch bashrematch nobashrematch bsd_echo no_bsd_echo bsdecho
+           \ nobsdecho continue_on_error no_continue_on_error continueonerror nocontinueonerror
+           \ csh_junkie_history no_csh_junkie_history cshjunkiehistory nocshjunkiehistory csh_junkie_loops
+           \ no_csh_junkie_loops cshjunkieloops nocshjunkieloops csh_junkie_quotes no_csh_junkie_quotes
+           \ cshjunkiequotes nocshjunkiequotes csh_nullcmd no_csh_nullcmd cshnullcmd nocshnullcmd ksh_arrays
+           \ no_ksh_arrays ksharrays noksharrays ksh_autoload no_ksh_autoload kshautoload nokshautoload
+           \ ksh_option_print no_ksh_option_print kshoptionprint nokshoptionprint ksh_typeset no_ksh_typeset
+           \ kshtypeset nokshtypeset ksh_zero_subscript no_ksh_zero_subscript kshzerosubscript
+           \ nokshzerosubscript posix_aliases no_posix_aliases posixaliases noposixaliases posix_argzero
+           \ no_posix_argzero posixargzero noposixargzero posix_builtins no_posix_builtins posixbuiltins
+           \ noposixbuiltins posix_identifiers no_posix_identifiers posixidentifiers noposixidentifiers
+           \ posix_strings no_posix_strings posixstrings noposixstrings posix_traps no_posix_traps posixtraps
+           \ noposixtraps sh_file_expansion no_sh_file_expansion shfileexpansion noshfileexpansion sh_nullcmd
+           \ no_sh_nullcmd shnullcmd noshnullcmd sh_option_letters no_sh_option_letters shoptionletters
+           \ noshoptionletters sh_word_split no_sh_word_split shwordsplit noshwordsplit traps_async
+           \ no_traps_async trapsasync notrapsasync interactive no_interactive nointeractive login no_login
+           \ nologin privileged no_privileged noprivileged restricted no_restricted norestricted shin_stdin
+           \ no_shin_stdin shinstdin noshinstdin single_command no_single_command singlecommand nosinglecommand
+           \ beep no_beep nobeep combining_chars no_combining_chars combiningchars nocombiningchars emacs
+           \ no_emacs noemacs overstrike no_overstrike nooverstrike single_line_zle no_single_line_zle
+           \ singlelinezle nosinglelinezle vi no_vi novi zle no_zle nozle brace_expand no_brace_expand
+           \ braceexpand nobraceexpand dot_glob no_dot_glob dotglob nodotglob hash_all no_hash_all hashall
+           \ nohashall hist_append no_hist_append histappend nohistappend hist_expand no_hist_expand histexpand
+           \ nohistexpand log no_log nolog mail_warn no_mail_warn mailwarn nomailwarn one_cmd no_one_cmd onecmd
+           \ noonecmd physical no_physical nophysical prompt_vars no_prompt_vars promptvars nopromptvars stdin
+           \ no_stdin nostdin track_all no_track_all trackall notrackall
 syn case match
 
 syn keyword zshTypes            float integer local typeset declare private readonly


### PR DESCRIPTION
Follow-up to my patch from last year: https://github.com/chrisbra/vim-zsh/pull/36

Current master branch (20 refreshes in my zshrc, Vim 8.2.4827):

	TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME
	0.673559   4400   2400    0.000644    0.000153  zshOption
	0.919166   151827                               total

With this patch zshOption doesn't appear in the :syntime report any more
(I looked at the syntime implementation, and it seems it's only recorded
for regexp matches in syn_regexec() and not keyword matches), but the
total is about a third of before, and the benchmark noticeably runs
faster:

	TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME
	0.342348   147927

Can reproduce/test with testing.vim[1] by running:

	% ~/code/Vim/testing.vim/tvim bench-syn ~/.zshrc:161

Line 161 is where I happen to have some setopts in my zshrc[2].

[1]: https://github.com/arp242/testing.vim
[2]: https://github.com/arp242/dotfiles/blob/e321600/zsh/zshrc#L161