### PR TITLE
Improve highlighting of zshRedir

### DIFF
--- a/syntax/zsh.vim
+++ b/syntax/zsh.vim
@@ -54,6 +54,12 @@ syn region  zshPOSIXString      matchgroup=zshStringDelimiter start=+\$'+
                                 \ skip=+\\[\\']+ end=+'+ contains=zshPOSIXQuoted,zshQuoted
 syn match   zshJobSpec          '%\(\d\+\|?\=\w\+\|[%+-]\)'
 
+syn match   zshNumber           '[+-]\=\<\d\+\>'
+syn match   zshNumber           '[+-]\=\<0x\x\+\>'
+syn match   zshNumber           '[+-]\=\<0\o\+\>'
+syn match   zshNumber           '[+-]\=\d\+#[-+]\=\w\+\>'
+syn match   zshNumber           '[+-]\=\d\+\.\d\+\>'
+
 syn keyword zshPrecommand       noglob nocorrect exec command builtin - time
 
 syn keyword zshDelimiter        do done end
@@ -78,8 +84,8 @@ syn match   zshFunction         '^\s*\k\+\ze\s*()'
 
 syn match   zshOperator         '||\|&&\|;\|&!\='
 
-syn match   zshRedir            '\d\=\(<\|<>\|<<<\|<&\s*[0-9p-]\=\)'
-syn match   zshRedir            '\d\=\(>\|>>\|>&\s*[0-9p-]\=\|&>\|>>&\|&>>\)[|!]\='
+syn match   zshRedir            '\d\=\(<<<\|<&\s*[0-9p-]\=\|<>\?\)'
+syn match   zshRedir            '\d\=\(>&\s*[0-9p-]\=\|&>>\?\|>>\?&\?\)[|!]\='
 syn match   zshRedir            '|&\='
 
 syn region  zshHereDoc          matchgroup=zshRedir
@@ -264,12 +270,6 @@ syn keyword zshTypes            float integer local typeset declare private read
 
 " XXX: this may be too much
 " syn match   zshSwitches         '\s\zs--\=[a-zA-Z0-9-]\+'
-
-syn match   zshNumber           '[+-]\=\<\d\+\>'
-syn match   zshNumber           '[+-]\=\<0x\x\+\>'
-syn match   zshNumber           '[+-]\=\<0\o\+\>'
-syn match   zshNumber           '[+-]\=\d\+#[-+]\=\w\+\>'
-syn match   zshNumber           '[+-]\=\d\+\.\d\+\>'
 
 " TODO: $[...] is the same as $((...)), so add that as well.
 syn cluster zshSubst            contains=zshSubst,zshOldSubst,zshMathSubst

--- a/tests/redir.zsh
+++ b/tests/redir.zsh
@@ -1,0 +1,37 @@
+#!/bin/zsh
+#
+# Test zshRedir.
+
+<word
+<>word
+>word    >|word >!word
+>>word  >>|word >>!word
+<<<word
+
+>&1 <&1 >& 1 <& 1
+<&- >&- <& - >& -
+<&p >&p <& p >& p
+>&word >&|word >&!word
+&>word &>|word &>!word
+
+>>&word >>&|word >>&!word
+&>>word &>>|word &>>!word
+
+>word   1>word   1>|word   1>!word
+>>word  1>>word  1>>|word  1>>!word
+>&word  1>&word  1>&|word  1>&!word
+>&1word 1>&2word 1>&2|word 1>&2!word
+
+>& 1 word >&p word >&word >&-word
+
+&>word   1&>word  1&>|word  1&>!word
+>>&word  1>>&word 1>>&|word 1>>&!word
+&>>word  1&>>word 1&>>|word 1&>>!word
+
+|&word
+
+# Named descriptors currently not highlighted.
+integer myfd
+exec {myfd}>~/logs/mylogfile.txt
+print This is a log message. >&$myfd
+exec {myfd}>&-


### PR DESCRIPTION
A few improvements for redirection operators:

- Because `>&\s*[0-9p-]\=` appears later than `>`, it would match only `>`. This
  is also a problem with `>>` and `>>&`.

- Numbers would sometimes get highlighted as number constants, but not always.
  For example in `1>` it would be highlighted as a number, and in `1>&2` only
  the `1` would.

  Could go two ways with this: always highlight as a number, or never. I opted
  for "never" as I felt that made more sense as it's part of the redirection.
  This is fixed by just moving the zshNumber up, before the zshRedir.

- Improve performance a bit by using `\?` optional matches rather than grouping.
  It's not a huge performance boost and downside it makes it a bit harder to
  read, but it does give a ~6% increase on my zshrc (see benchmarks below).

- I left `tests/redir.zsh` as a little manual "test" for all permutations; I
  thought that would be useful for the future, but I can remove it if you don't
  find it useful.

---

With `tvim bench-syn ~/.zshrc:161`

Before:

	TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME      PATTERN
	0.033411   2941   2       0.000087    0.000011  zshRedir  \d\=\(>\|>>\|>&\s*[0-9p-]\=\|&>\|>>&\|&>>\)[|!]
	0.024738   2941   0       0.000087    0.000008  zshRedir  \d\=\(<\|<>\|<<<\|<&\s*[0-9p-]\=\)
	0.000676   3043   102     0.000022    0.000000  zshRedir  |&\=

	0.316220   150242

After:

	TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME        PATTERN
	0.021872   2941   2       0.000061    0.000007  zshRedir    \d\=\(>&\s*[0-9p-]\=\|&>>\?\|>>\?&\?\)[|!]\=
	0.021456   2941   0       0.000055    0.000007  zshRedir    \d\=\(<<<\|<&\s*[0-9p-]\=\|<>\?\)
	0.000722   3043   102     0.000011    0.000000  zshRedir    |&\=

	0.298003   150237

---

Before:

![cap-2022-04-27T17:47:43](https://user-images.githubusercontent.com/1032692/165561600-2eb9982b-11db-4c82-8529-eeb1e09f3266.png)

After:

![cap-2022-04-27T17:47:27](https://user-images.githubusercontent.com/1032692/165561596-7df08bce-f8bb-4677-9829-901239a5aa6e.png)