### PR TITLE
Change submodule URL to not require a SSH key

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "testing.vim"]
 	path = testing.vim
-	url = git@github.com:arp242/testing.vim.git
+	url = https://github.com/arp242/testing.vim.git


### PR DESCRIPTION
Use the testing submodule's public web URL.

The `git@github.com` URL can cause installation within automated environments (such as within docker) to fail if they don't have a configured github SSH key.

Example error messages:

```
[dein] Submodule 'testing.vim' (git@github.com:arp242/testing.vim.git) registered for path 'testing.vim'
[dein] Cloning into '/home/user/.cache/vimfiles/repos/github.com/chrisbra/vim-zsh/testing.vim'...
[dein] Host key verification failed.
[dein] fatal: Could not read from remote repository.
[dein] Please make sure you have the correct access rights
[dein] and the repository exists.

[dein] Submodule 'testing.vim' (git@github.com:arp242/testing.vim.git) registered for path 'testing.vim'
[dein] Cloning into '/home/user/.cache/vimfiles/repos/github.com/chrisbra/vim-zsh/testing.vim'...
[dein] git@github.com: Permission denied (publickey).
[dein] fatal: Could not read from remote repository.
```