### PR TITLE
Link zshOperator to Operator

### DIFF
--- a/syntax/zsh.vim
+++ b/syntax/zsh.vim
@@ -333,7 +333,7 @@ hi def link zshKeyword          Keyword
 hi def link zshFunction         None
 hi def link zshKSHFunction      zshFunction
 hi def link zshHereDoc          String
-hi def link zshOperator         None
+hi def link zshOperator         Operator
 hi def link zshRedir            Operator
 hi def link zshVariable         None
 hi def link zshVariableDef      zshVariable


### PR DESCRIPTION
This highlights ZSH operators like `&&` as operators.

A long time ago it looked like there was a thought that either operators or redirection should be highlighted as operators, with redirection getting linked in the end (9215b31). However, these are not mutually exclusive. It's also uncommon to have an operator adjacent to a redirection, so there's no cause for confusion.